### PR TITLE
Update Links after Repo Transfer

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "9.6", "9.8", "9.10", "9.12" ]
+        ghc: [ "9.6", "9.8", "9.10" ]
         trexio: [ "2.5.0" ]
     name: GHC ${{ matrix.ghc }}, Trexio ${{ matrix.trexio }}
     steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're using Nix, you can include these bindings as an overlay, e.g. such a `
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-    trexio-hs.url = "github:sheepforce/trexio-hs";
+    trexio-hs.url = "github:TREX-CoE/trexio-hs";
   };
 
   outputs = 
@@ -32,7 +32,7 @@ If you're using Nix, you can include these bindings as an overlay, e.g. such a `
 
 ```
 
-Of course, you can also simply build the project via `nix build github:sheepforce/trexio-hs`.
+Of course, you can also simply build the project via `nix build github:TREX-CoE/trexio-hs`.
 
 ### Cabal
 This package is on Hackage: <https://hackage.haskell.org/package/trexio-hs>

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734359469,
-        "narHash": "sha256-NuYABf+URWfc0LHSv5nYNhbh0hW+E+U4vjxnFuv7K2I=",
+        "lastModified": 1736158417,
+        "narHash": "sha256-i0ySPtc5QZnPQyhM6vEHatmlhMgYoCnoK8kFtQPuyaM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3175ce85131b128562f362780ee538e37dde2fab",
+        "rev": "ba7ff8141b3ec2b1ac4bc1561d7c875d1e54c1e7",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1733930112,
-        "narHash": "sha256-VWx76RsTRHBq4fnwrfqmqHPSlELIzLRMWHzXxoRbtXY=",
+        "lastModified": 1735852477,
+        "narHash": "sha256-i+S99sMQTcLjSJEn6LPy/r48X8dDs0IqFxPTzbqb1qc=",
         "owner": "TREX-CoE",
         "repo": "trexio",
-        "rev": "df0e3a8e1c4c98de29f5850da86d94f2572fda93",
+        "rev": "ccb9bf8587020d272306c7248121c09329021a7b",
         "type": "github"
       },
       "original": {

--- a/trexio-hs.cabal
+++ b/trexio-hs.cabal
@@ -16,7 +16,7 @@ maintainer:         phillip.seeber@uni-jena.de
 category:           Data
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
-tested-with:        GHC == {9.6, 9.8, 9.10, 9.12}
+tested-with:        GHC == {9.6, 9.8, 9.10}
 description:
     This package provides low- and high-level Haskell bindings for [TREXIO, a portable file format for storing wave function data](https://trex-coe.github.io/trexio/).
     The vast majority of the bindings in this package is generated via TemplateHaskell from the TREXIO JSON specification, that then defines the C-API.


### PR DESCRIPTION
Updates links in the README to reflect the new URL after repository has moved to the TREX-CoE organisation.