### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v30
+    - uses: cachix/install-nix-action@v31.4.1
     - run: |
         nix flake check -L

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "9.6", "9.8", "9.10" ]
+        ghc: [ "9.6", "9.8", "9.10", "9.12" ]
         trexio: [ "2.5.0" ]
     name: GHC ${{ matrix.ghc }}, Trexio ${{ matrix.trexio }}
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install -y libhdf5-dev
-          wget https://github.com/TREX-CoE/trexio/releases/download/v2.5.0/trexio-2.5.0.tar.gz
+          wget https://github.com/TREX-CoE/trexio/releases/download/v${{ matrix.trexio }}/trexio-${{ matrix.trexio }}.tar.gz
           tar -xvf trexio-${{ matrix.trexio }}.tar.gz
           cd trexio-${{ matrix.trexio }}
           ./configure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for trexio-hs
 
-## 0.1.0 -- YYYY-mm-dd
+## 0.1.1 -- 2025-07-10
+
+* Adapt test suite for more restrictive checks for various fields such as determinant_list
+* Fix memory corruption bug with determinant IO
+
+## 0.1.0 -- 2025-01-06
 
 * First version. Released on an unsuspecting world.

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736158417,
-        "narHash": "sha256-i0ySPtc5QZnPQyhM6vEHatmlhMgYoCnoK8kFtQPuyaM=",
+        "lastModified": 1751467336,
+        "narHash": "sha256-GJoG7cEb85IGbntzi6F64RC8E9WDzCrTmUv5cNVSXUY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba7ff8141b3ec2b1ac4bc1561d7c875d1e54c1e7",
+        "rev": "a32c78d3a036db2b4de839d1ddd1ea84caee7c92",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1735852477,
-        "narHash": "sha256-i+S99sMQTcLjSJEn6LPy/r48X8dDs0IqFxPTzbqb1qc=",
+        "lastModified": 1751467230,
+        "narHash": "sha256-FDK6S+mLKYnLW6UrrT1LvJm7t3nErOjWbSgwdvLOpFk=",
         "owner": "TREX-CoE",
         "repo": "trexio",
-        "rev": "ccb9bf8587020d272306c7248121c09329021a7b",
+        "rev": "af5da3a8a046533600aa13f568fc370febede5a1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
           withHoogle = true;
           packages = p: [ p.trexio-hs ];
           buildInputs = with pkgs; [
+            cabal-install
             haskell-language-server
             haskellPackages.fourmolu
             haskellPackages.haskell-ci
@@ -53,6 +54,7 @@
           ghc96 = pkgs.haskell.packages.ghc96.trexio-hs;
           ghc98 = pkgs.haskell.packages.ghc98.trexio-hs;
           ghc910 = pkgs.haskell.packages.ghc910.trexio-hs;
+          ghc912 = pkgs.haskell.packages.ghc912.trexio-hs;
         };
       }
     )

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ /*trexio.overlays.default*/ trexioOvl ];
+          overlays = [ trexioOvl trexio.overlays.default ];
         };
       in
       {

--- a/src-int/TREXIO/Internal/Base.hsc
+++ b/src-int/TREXIO/Internal/Base.hsc
@@ -234,22 +234,16 @@ foreign import capi "trexio.h trexio_close" close_ :: Trexio -> IO ExitCodeC
 close :: (MonadIO m, MonadThrow m) => Trexio -> m ()
 close trexio = checkEC $ close_ trexio
 
-foreign import capi "trexio.h trexio_get_int64_num" intsPerDet_ :: 
-  Trexio ->
-  Ptr CInt ->
-  IO ExitCodeC
-
--- | Get the number of 'Int64's required to store a single determinant. This is a
--- convenience function that avoids manual calculation via the size if Int64 and
--- the number of MOs.
-intsPerDet :: (MonadIO m, MonadThrow m) => Trexio -> m Int
-intsPerDet trexio = liftIO . alloca $ \nPtr -> do
-  checkEC $ intsPerDet_ trexio nPtr
-  fromIntegral <$> peek nPtr
-
 foreign import capi "trexio.h trexio_mark_safety" markSafety_ :: Trexio -> Int32 -> IO ExitCodeC
 
 -- | After a file has been opened unsafely, it can be marked as safe by this function 
 -- forcefully. You are responsible for internal incosistencies that may arise from this.
 markSafety :: (MonadIO m, MonadThrow m) => Trexio -> m ()
 markSafety trexio = checkEC $ markSafety_ trexio 0
+
+--------------------------------------------------------------------------------
+
+-- | Bit field type for storing determinant information.
+newtype BitFieldT = BitFieldT Int64
+  deriving (Eq, Ord, Show)
+  deriving Storable via (Int64)

--- a/src/TREXIO.hs
+++ b/src/TREXIO.hs
@@ -78,7 +78,6 @@ module TREXIO (
 
     -- * High Level Interface
     scheme,
-    intsPerDet,
     withTrexio,
     module TREXIO.HighLevel,
 ) where

--- a/src/TREXIO/HighLevel.hs
+++ b/src/TREXIO/HighLevel.hs
@@ -18,6 +18,9 @@ import Data.Map qualified as Map
 import Data.Massiv.Array as Massiv hiding (Dim, forM)
 import Foreign.C.ConstPtr
 import Foreign.C.Types
+import Foreign.Marshal.Alloc
+import Foreign.Ptr
+import Foreign.Storable
 import Language.Haskell.TH
 import TREXIO.Internal.Base
 import TREXIO.Internal.TH
@@ -38,3 +41,12 @@ $( do
             return $ hasBind <> readBind <> writeBind
         return $ deleteBind <> fieldBinds
  )
+
+{- | Get the number of 'Int64's required to store a single determinant. This is a
+convenience function that avoids manual calculation via the size if Int64 and
+the number of MOs.
+-}
+intsPerDet :: (MonadIO m, MonadThrow m) => Trexio -> m Int
+intsPerDet trexio = liftIO . alloca $ \nPtr -> do
+    checkEC $ trexio_get_int64_num trexio nPtr
+    fromIntegral <$> peek nPtr

--- a/src/TREXIO/LowLevel.hs
+++ b/src/TREXIO/LowLevel.hs
@@ -16,9 +16,11 @@ Consequently, they are unsafe and require manual memory management.
 -}
 module TREXIO.LowLevel where
 
+import Data.Int
 import Data.Map qualified as Map
 import Foreign.C.ConstPtr
 import Foreign.C.Types
+import Foreign.Ptr
 import TREXIO.Internal.Base
 import TREXIO.Internal.TH
 import TREXIO.LowLevel.Scheme
@@ -30,3 +32,23 @@ $( do
     -- Import all C functions for all fields and operations
     concat <$> traverse (uncurry mkCBindings) groups
  )
+
+-- | 'Int64's required per determinant
+foreign import capi "trexio.h trexio_get_int64_num"
+    trexio_get_int64_num ::
+        Trexio ->
+        Ptr CInt ->
+        IO ExitCodeC
+
+-- | Take a list of occupied orbital indices and create a bitfield from it
+foreign import capi "trexio.h trexio_to_bitfield_list"
+    trexio_to_bitfield_list ::
+        -- | @orb_list@
+        ConstPtr Int32 ->
+        -- | @occupied_num@
+        Int32 ->
+        -- | Preallocated, zeroed bit array representing a determinant
+        ConstPtr Int64 ->
+        -- | Number of Int64 required per determinant as obtained by 'trexio_get_int64_num'
+        Int32 ->
+        IO ExitCodeC

--- a/test/trexio-test.hs
+++ b/test/trexio-test.hs
@@ -1,10 +1,13 @@
+import Control.Concurrent (threadDelay)
 import Control.Exception.Safe
 import Control.Monad
 import Data.Bit.ThreadSafe (Bit)
 import Data.Massiv.Array as Massiv hiding (Size, elem, forM, forM_, mapM, mapM_, take, zip, zipWith)
+import Data.Massiv.Array qualified as Massiv
 import Data.Maybe (catMaybes, fromJust)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Debug.Trace
 import Hedgehog (Gen, MonadGen, Size, forAll, property, (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
@@ -48,38 +51,52 @@ tests =
             , testGroup "Strings" . appFn $
                 [ ("metadata.author", genVector genIdentifier, deleteMetadata, hasMetadataAuthor, readMetadataAuthor, writeMetadataAuthor)
                 ]
-            , testCase "Determinant IO" . withSystemTempFile "trexio.dat" $ \fp _ ->
-                withTrexio fp FileWrite Hdf5 $ \trexio -> do
-                    writeMoNum trexio 3
+            , testProperty "Determinant IO" . property $ do
+                -- Generate occupation numbers
+                nMo <- forAll $ Gen.int (Range.linear 1 1000)
+                nUp <- forAll $ Gen.int (Range.linear 2 (nMo - 1))
+                nDn <- forAll $ Gen.int (Range.linear 2 (nMo - 1))
 
-                    has1 <- hasDeterminantList trexio
-                    has1 @?= False
+                -- Generate determinants
+                dets <- forAll $ genDet nMo (nUp, nDn)
+                let Sz2 nDets _ = Massiv.size dets
 
-                    ingoreExcp [AttrMissing] (readDeterminantList trexio)
+                -- Generate coefficients
+                let
+                coeffs <- forAll . fmap (Massiv.fromList Par) $ Gen.list (Range.singleton nDets) (Gen.double $ Range.linearFrac (-10) 10)
 
-                    let detList =
-                            Massiv.fromLists' @U @Ix2 @(Bit, Bit)
-                                Seq
-                                [ [(1, 1), (1, 0), (0, 0)]
-                                , [(1, 0), (1, 1), (0, 0)]
-                                ]
-                        detCoeffs = Massiv.fromList @S @Double Seq [1.0, 2.0]
+                liftIO $ withSystemTempFile "trexio.dat" $ \fp _ ->
+                    withTrexio fp FileWrite Hdf5 $ \trexio -> do
+                        -- Write MO numbers and electron occupation numbers to the file
+                        writeMoNum trexio nMo
+                        writeElectronUpNum trexio nUp
+                        writeElectronDnNum trexio nDn
 
-                    writeElectronUpNum trexio 2
-                    writeElectronDnNum trexio 1
+                        nMo' <- readMoNum trexio
+                        nUp' <- readElectronUpNum trexio
+                        nDn' <- readElectronDnNum trexio
 
-                    writeDeterminantList trexio detList
+                        -- Check
+                        nMo @?= nMo'
+                        nUp @?= nUp'
+                        nDn @?= nDn'
 
-                    has2 <- hasDeterminantList trexio
-                    has2 @?= True
+                        -- Write determinants
+                        writeDeterminantList trexio dets
 
-                    detList' <- readDeterminantList trexio
-                    detList' @?= detList
+                        -- Read back determinants
+                        readDets <- readDeterminantList trexio
 
-                    writeDeterminantCoefficient trexio detCoeffs
+                        -- Check for equality
+                        dets @?= readDets
 
-                    detCoeffs' <- readDeterminantCoefficient trexio
-                    detCoeffs' @?= detCoeffs
+                        -- Write coefficients
+                        writeDeterminantCoefficient trexio coeffs
+
+                        -- Read back coefficients
+                        coeffs' <- readDeterminantCoefficient trexio
+
+                        coeffs @?= coeffs'
             ]
         , testGroup
             "2D"
@@ -195,6 +212,9 @@ genDim = Gen.integral (Range.linear 1 100)
 -- | Generate a random index, which is a non-negative integer
 genIndex :: Gen Int
 genIndex = Gen.integral (Range.linear 0 1000)
+
+genMoIndex :: Gen Word
+genMoIndex = Gen.word (Range.linear 0 300)
 
 genFloat :: Gen Double
 genFloat = Gen.realFloat (Range.linearFrac (-1_000_000) 1_000_000)
@@ -454,3 +474,34 @@ scaleSparse = Gen.scale sz2zs
   where
     sz2zs :: Size -> Size
     sz2zs x = round $ fromIntegral x * (0.25 :: Double)
+
+-- | Generate multiple determinants valid for given system
+genDet ::
+    -- | Number of MOs in the system
+    Int ->
+    -- | Number of Up and Down electrons
+    (Int, Int) ->
+    -- | List of determinants
+    Gen (Matrix U (Bit, Bit))
+genDet nMo (nUp, nDn) = do
+    detsL <- Gen.set (Range.linear 1 100) detGen
+    dets <- case Massiv.stackOuterSlicesM . Set.toList $ detsL of
+        Nothing -> error "Failed to stack slices"
+        Just dets' -> return dets'
+    return . compute $ dets
+  where
+    occGen :: (MonadGen m) => Int -> m (Set.Set Int)
+    occGen nOcc = Gen.set (Range.singleton nOcc) (Gen.int (Range.linear 0 (nMo - 1)))
+
+    detGen :: (MonadGen m) => m (Massiv.Vector U (Bit, Bit))
+    detGen = do
+        -- Generate indices of occupied orbitals
+        occUp <- occGen nUp
+        occDn <- occGen nDn
+
+        -- Generate a single determinant
+        let detUp = makeArray @U Par (Sz nMo) $ \i -> if i `Set.member` occUp then 1 else 0
+            detDn = makeArray @U Par (Sz nMo) $ \i -> if i `Set.member` occDn then 1 else 0
+            det = Massiv.zip detUp detDn
+
+        return . compute $ det

--- a/trexio-hs.cabal
+++ b/trexio-hs.cabal
@@ -75,7 +75,7 @@ common deps
         bitvec >= 1.1.5.0 && < 1.2,
         bytestring >= 0.10 && < 0.13,
         casing >= 0.1.4 && < 0.2,
-        containers >= 0.6 && < 0.8,
+        containers >= 0.6 && < 0.9,
         filepath >= 1.4 && < 1.6,
         massiv >= 1.0.0.0 && < 1.1,
         safe-exceptions >= 0.1.7 && < 0.2,

--- a/trexio-hs.cabal
+++ b/trexio-hs.cabal
@@ -16,7 +16,7 @@ maintainer:         phillip.seeber@uni-jena.de
 category:           Data
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
-tested-with:        GHC == {9.6, 9.8, 9.10}
+tested-with:        GHC == {9.6, 9.8, 9.10, 9.12}
 description:
     This package provides low- and high-level Haskell bindings for [TREXIO, a portable file format for storing wave function data](https://trex-coe.github.io/trexio/).
     The vast majority of the bindings in this package is generated via TemplateHaskell from the TREXIO JSON specification, that then defines the C-API.

--- a/trexio-hs.cabal
+++ b/trexio-hs.cabal
@@ -7,7 +7,7 @@ name:               trexio-hs
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:            0.1.0
+version:            0.1.1
 synopsis: Bindings to the TREXIO library for wave function data
 homepage:           https://github.com/TREX-CoE/trexio-hs
 license:            BSD-3-Clause


### PR DESCRIPTION
This updates the dependencies:

- Cabal dependencies to support latest containers version
- The flake.lock to latest nixpkgs and trexio
- adds GHC 9.12 build
- uses trexio from upstream git repo instead of nixpkgs version

With recent upstream TREXIO more strict sanity checks for some versions were introduced. Adapt the test suite to the new behaviour.

Furthermore, this PR fixes a memory corruption issue with Determinant IO.