### PR TITLE
Ecosystem updates

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v31.4.1
+    - uses: cachix/install-nix-action@v31.9.1
     - run: |
         nix flake check -L

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: [ "9.6", "9.8", "9.10", "9.12" ]
-        trexio: [ "2.5.0", "2.6.0" ]
+        trexio: [ "2.5.0", "2.6.0", "2.6.1" ]
     name: GHC ${{ matrix.ghc }}, Trexio ${{ matrix.trexio }}
     steps:
       - name: Checkout

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Build trexio-hs
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          cabal build --extra-lib-dirs=/usr/local/lib
+          cabal build --enable-tests --extra-lib-dirs=/usr/local/lib
       
       - name: Test trexio-hs
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          cabal test --extra-lib-dirs=/usr/local/lib
+          cabal test --enable-tests --extra-lib-dirs=/usr/local/lib

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754297008,
-        "narHash": "sha256-kGlYI6sSVWjLdpFIFqwbA2uECHCN47HTFsDE1ox8gdk=",
+        "lastModified": 1771525516,
+        "narHash": "sha256-t9QYIuU+21iNFG+AO3T9u9FclWaKPlnynGZmdiSsQ9c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9606828cbe6f779357e11d59c7392a75b6a471",
+        "rev": "d6bd58dc0cb04acb625f2221215882dd1e0f9cfd",
         "type": "github"
       },
       "original": {
@@ -109,15 +109,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1754145328,
-        "narHash": "sha256-DWpbzemrdJ1mC5ZuNEDhaoH/RVZWTH4001hggAcVjcM=",
+        "lastModified": 1770232085,
+        "narHash": "sha256-iESt7dXta/Enpgb418js26y5+YvROsqgxvNhgAgXd/I=",
         "owner": "TREX-CoE",
         "repo": "trexio",
-        "rev": "68f35b024032fe154ebec8d70f3b8cb4a35a4428",
+        "rev": "001c06bb44b6667b26167e3e6bc792a6a30d5abe",
         "type": "github"
       },
       "original": {
         "owner": "TREX-CoE",
+        "ref": "v2.6.1",
         "repo": "trexio",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
 
     nixpkgs.url = "github:NixOS/nixpkgs";
 
-    trexio.url = "github:TREX-CoE/trexio";
+    trexio.url = "github:TREX-CoE/trexio/v2.6.1";
   };
 
   outputs =

--- a/trexio-hs.cabal
+++ b/trexio-hs.cabal
@@ -23,6 +23,7 @@ description:
 
       * 2.5.0
       * 2.6.0
+      * 2.6.1
 
     The vast majority of the bindings in this package is generated via TemplateHaskell from the TREXIO JSON specification, that then defines the C-API.
     For more details see the [TREXIO documentation](https://trex-coe.github.io/trexio/lib.html).
@@ -88,7 +89,7 @@ common deps
         filepath >= 1.4 && < 1.6,
         massiv >= 1.0.0.0 && < 1.1,
         safe-exceptions >= 0.1.7 && < 0.2,
-        template-haskell >= 2.19 && < 2.24,
+        template-haskell >= 2.19 && < 2.25,
         temporary >= 1.3 && < 1.4,
         typed-process >= 0.2.12 && < 0.3,
         text >= 2.0 && < 2.2,
@@ -156,4 +157,4 @@ test-suite trexio-test
         tasty >= 1.4 && < 1.6,
         tasty-hunit >= 0.10 && < 0.11,
         tasty-hedgehog >= 1.4 && < 1.5,
-        hedgehog >= 1.4 && < 1.6
+        hedgehog >= 1.4 && < 1.8


### PR DESCRIPTION
This updates the repository to all current versions in the ecosystem:

* upper version bounds in cabal have been updated to support the latest versions in the Haskell ecosystem of all dependencies
* the flake.nix pins the current trexio version (2.6.1)
* the flake.lock has been updated with current nixpkgs-unstable
* github actions have been update to latest nix-install action
* GHC 9.14 has been added to the test matrix